### PR TITLE
Reverse proxy for Subgraph HTTP

### DIFF
--- a/lib/ethui/services/graph.ex
+++ b/lib/ethui/services/graph.ex
@@ -185,7 +185,6 @@ defmodule Ethui.Services.Graph do
 
     args =
       format_docker_args(env, ports, named_args, flags)
-      |> IO.inspect()
 
     MuonTrap.Daemon.start_link("docker", args,
       logger_fun: fn f -> GenServer.cast(pid, {:log, f}) end,

--- a/lib/ethui_web/controllers/api/stack_controller.ex
+++ b/lib/ethui_web/controllers/api/stack_controller.ex
@@ -5,8 +5,6 @@ defmodule EthuiWeb.Api.StackController do
   alias Ethui.Repo
 
   def index(conn, _params) do
-    IO.inspect(conn)
-
     anvils =
       Server.list()
 

--- a/lib/ethui_web/controllers/api/stack_controller.ex
+++ b/lib/ethui_web/controllers/api/stack_controller.ex
@@ -5,6 +5,8 @@ defmodule EthuiWeb.Api.StackController do
   alias Ethui.Repo
 
   def index(conn, _params) do
+    IO.inspect(conn)
+
     anvils =
       Server.list()
 

--- a/lib/ethui_web/controllers/proxy_controller.ex
+++ b/lib/ethui_web/controllers/proxy_controller.ex
@@ -34,7 +34,7 @@ defmodule EthuiWeb.ProxyController do
     case Graph.ip(slug) do
       {:ok, ip} ->
         url = "http://#{ip}:8000/#{path}"
-        forward(conn, :get, url, "/stacks/#{slug}/subgraph")
+        forward(conn, url, "/stacks/#{slug}/subgraph")
 
       error ->
         conn
@@ -66,7 +66,7 @@ defmodule EthuiWeb.ProxyController do
     # end
   end
 
-  defp forward(conn, method, url, base_path) do
+  defp forward(conn, url, base_path) do
     with {:ok, method} <- method_sym(conn.method),
          {:ok, conn} <-
            send_request(conn, method: method, url: url, query: conn.query_params) do

--- a/lib/ethui_web/router.ex
+++ b/lib/ethui_web/router.ex
@@ -56,8 +56,7 @@ defmodule EthuiWeb.Router do
 
     scope "/:slug" do
       get "/log", LogController, :show
-      get "/subgraph/*path", ProxyController, :subgraph_http_get
-      post "/subgraph/*path", ProxyController, :subgraph_http_post
+      match :*, "/subgraph/*path", ProxyController, :subgraph_http
       post "/", ProxyController, :anvil
     end
   end

--- a/lib/ethui_web/router.ex
+++ b/lib/ethui_web/router.ex
@@ -17,6 +17,7 @@ defmodule EthuiWeb.Router do
   end
 
   pipeline :proxy do
+    plug :accepts, ["json"]
     # explicitly empty for clarity
     # we don't want any plugs here since that makes assumptions on the request type,
     # and proxy endpoints should support GET/POST, html/json, etc
@@ -57,7 +58,7 @@ defmodule EthuiWeb.Router do
     scope "/:slug" do
       get "/log", LogController, :show
       match :*, "/", ProxyController, :anvil
-      match :*, "/subgraph/*path", ProxyController, :subgraph_http
+      match :*, "/subgraph/*proxied_path", ProxyController, :subgraph_http
     end
   end
 

--- a/lib/ethui_web/router.ex
+++ b/lib/ethui_web/router.ex
@@ -56,8 +56,8 @@ defmodule EthuiWeb.Router do
 
     scope "/:slug" do
       get "/log", LogController, :show
+      match :*, "/", ProxyController, :anvil
       match :*, "/subgraph/*path", ProxyController, :subgraph_http
-      post "/", ProxyController, :anvil
     end
   end
 


### PR DESCRIPTION
This will allow us to not expose subgraph docker ports, which in turn means we're no longer limited by the amount of ports we have available