### PR TITLE
Add automatic creation and validation of docker network before startup

### DIFF
--- a/lib/ethui/services/docker.ex
+++ b/lib/ethui/services/docker.ex
@@ -119,6 +119,10 @@ defmodule Ethui.Services.Docker do
         args =
           format_docker_args(image, env, named_args, volumes, flags)
 
+        if named_args[:network] do
+          ensure_network_exists(named_args[:network])
+        end
+
         if named_args[:name] do
           wait_for_removal(named_args[:name])
         end
@@ -192,6 +196,13 @@ defmodule Ethui.Services.Docker do
         trim(q, limit)
       else
         q
+      end
+    end
+
+    def ensure_network_exists(network_name) do
+      case System.cmd("docker", ["network", "inspect", network_name]) do
+        {_, 0} -> :ok
+        {_, _} -> System.cmd("docker", ["network", "create", network_name])
       end
     end
   end


### PR DESCRIPTION
##  Why

We weren't checking if the docker network existed before trying to startup the containers. 
Unless you had created the network manually before the applications would crash.

##  How

* Check if the named args contain a network name argument 
* If so, check if the network exists
* If it doesn't then create it