### PR TITLE
Add anvil optional arguments on stack creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Elixir CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -13,36 +13,36 @@ concurrency:
 jobs:
   #
   # run test suite
-  # 
+  #
   test:
     runs-on: ubuntu-latest
     env:
       MIX_ENV: test
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - uses: erlef/setup-beam@v1
-      with:
-        elixir-version: '1.18.3'
-        otp-version: 'OTP-27'
+      - uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.18.3"
+          otp-version: "OTP-27"
 
-    - uses: foundry-rs/foundry-toolchain@v1
+      - uses: foundry-rs/foundry-toolchain@v1
 
-    - uses: actions/cache@v4
-      with:
-        path: |
-          deps
-          _build
-        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-mix-
+      - uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-${{ hashFiles('mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
 
-    - run: mix deps.get
-    - run: mix compile
-    - run: mix ecto.create
-    - run: mix ecto.migrate
-    - run: mix credo
-    - run: mix test
+      - run: mix deps.get
+      - run: mix compile
+      - run: mix ecto.create
+      - run: mix ecto.migrate
+      - run: mix credo
+      - run: mix test
 
   #
   # builds public docker image
@@ -57,16 +57,16 @@ jobs:
       attestations: write
       id-token: write
     steps:
-    - uses: actions/checkout@v4
-    - uses: docker/setup-buildx-action@v3
-    - uses: macbre/push-to-ghcr@v14
-      with:
-        image_name: ${{ github.repository }}
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: macbre/push-to-ghcr@v14
+        with:
+          image_name: ${{ github.repository }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   #
   # deploy stacks.ethui.devices:
-  # 
+  #
   deploy:
     runs-on: ubuntu-latest
     needs: test
@@ -78,35 +78,35 @@ jobs:
       SSH_URL: ${{ vars.DIGITALOCEAN_USER }}@${{ vars.DIGITALOCEAN_HOST }}
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: erlef/setup-beam@v1
-      with:
-        elixir-version: '1.18.3'
-        otp-version: 'OTP-27'
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.18.3"
+          otp-version: "OTP-27"
 
-    - run: mix deps.get
-    - run: mix compile
-    - run: mix release
+      - run: mix deps.get
+      - run: mix compile
+      - run: mix release
 
-    - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1, hardcoded hash for security
-      with:
-        ssh-private-key: ${{ secrets.DIGITALOCEAN_DEPLOY_KEY }}
+      - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1, hardcoded hash for security
+        with:
+          ssh-private-key: ${{ secrets.DIGITALOCEAN_DEPLOY_KEY }}
 
-    - run: ssh-keyscan ${{ vars.DIGITALOCEAN_HOST }} >> ~/.ssh/known_hosts
+      - run: ssh-keyscan ${{ vars.DIGITALOCEAN_HOST }} >> ~/.ssh/known_hosts
 
-    - name: Create deploy dir
-      run: ssh $SSH_URL 'mkdir -p stacks.ethui.dev'
+      - name: Create deploy dir
+        run: ssh $SSH_URL 'mkdir -p stacks.ethui.dev'
 
-    - name: Upload
-      run: |
-        rsync -az --delete _build/prod/rel/ethui/ \
-          $SSH_URL:${{ vars.DEPLOY_PATH }}/build-new
+      - name: Upload
+        run: |
+          rsync -az --delete _build/prod/rel/ethui/ \
+            $SSH_URL:${{ vars.DEPLOY_PATH }}/build-new
 
-    - name: Upload release script
-      run: scp .github/scripts/deploy.sh $SSH_URL:/tmp/stacks-deploy.sh
+      - name: Upload release script
+        run: scp .github/scripts/deploy.sh $SSH_URL:/tmp/stacks-deploy.sh
 
-    - name: Chmod deploy script
-      run: ssh $SSH_URL "chmod +x /tmp/stacks-deploy.sh"
+      - name: Chmod deploy script
+        run: ssh $SSH_URL "chmod +x /tmp/stacks-deploy.sh"
 
-    - name: Run deploy script
-      run: ssh $SSH_URL "/tmp/stacks-deploy.sh '${{ vars.DEPLOY_PATH }}'"
+      - name: Run deploy script
+        run: ssh $SSH_URL "/tmp/stacks-deploy.sh '${{ vars.DEPLOY_PATH }}'"

--- a/lib/ethui/accounts/user.ex
+++ b/lib/ethui/accounts/user.ex
@@ -57,4 +57,3 @@ defmodule Ethui.Accounts.User do
     })
   end
 end
-

--- a/lib/ethui/services/anvil.ex
+++ b/lib/ethui/services/anvil.ex
@@ -100,7 +100,7 @@ defmodule Ethui.Services.Anvil do
          slug: opts[:slug],
          log_subscribers: MapSet.new(),
          chain_id: chain_id(),
-         opts: opts_to_args(opts[:anvil_opts])
+         args: opts_to_args(opts[:anvil_opts])
        }}
     else
       error -> error
@@ -108,7 +108,7 @@ defmodule Ethui.Services.Anvil do
   end
 
   @impl GenServer
-  def handle_info(:boot, %{port: port, dir: dir, chain_id: chain_id, opts: opts} = state) do
+  def handle_info(:boot, %{port: port, dir: dir, chain_id: chain_id, args: args} = state) do
     pid = self()
 
     anvil_args =
@@ -121,7 +121,7 @@ defmodule Ethui.Services.Anvil do
         "0.0.0.0",
         "--chain-id",
         to_string(chain_id)
-      ] ++ opts
+      ] ++ args
 
     case MuonTrap.Daemon.start_link(
            anvil_bin(),

--- a/lib/ethui/services/anvil.ex
+++ b/lib/ethui/services/anvil.ex
@@ -12,8 +12,8 @@ defmodule Ethui.Services.Anvil do
 
   @type id :: pid | atom | {:via, atom, term}
 
-  @type allowed_value :: String.t() | number()
-  @type opts_map :: %{optional(String.t()) => allowed_value()}
+  @type opts_value :: String.t() | number()
+  @type opts_map :: %{optional(String.t()) => opts_value()}
 
   @type opts :: [
           slug: String.t(),

--- a/lib/ethui/stacks/multi_stack_supervisor.ex
+++ b/lib/ethui/stacks/multi_stack_supervisor.ex
@@ -25,7 +25,7 @@ defmodule Ethui.Stacks.MultiStackSupervisor do
   def start_stack(opts) do
     opts = [
       slug: opts[:slug],
-      anvil: [slug: opts[:slug], hash: opts[:hash]],
+      anvil: [slug: opts[:slug], hash: opts[:hash], anvil_opts: opts[:anvil_opts]],
       graph: [slug: opts[:slug], hash: opts[:hash]]
     ]
 

--- a/lib/ethui/stacks/server.ex
+++ b/lib/ethui/stacks/server.ex
@@ -118,7 +118,7 @@ defmodule Ethui.Stacks.Server do
 
   @spec start_stack(map, t) :: {:ok, pid, t} | {:error, any}
   defp start_stack(
-         %{slug: slug, inserted_at: inserted_at},
+         %{slug: slug, anvil_opts: anvil_opts, inserted_at: inserted_at},
          %{instances: instances} = state
        ) do
     hash =
@@ -127,7 +127,7 @@ defmodule Ethui.Stacks.Server do
       |> binary_part(0, 8)
       |> String.downcase()
 
-    full_opts = [slug: slug, hash: hash]
+    full_opts = [slug: slug, hash: hash, anvil_opts: anvil_opts]
     Logger.info("Starting stack #{slug}")
 
     case MultiStackSupervisor.start_stack(full_opts) do

--- a/lib/ethui/stacks/stack.ex
+++ b/lib/ethui/stacks/stack.ex
@@ -36,4 +36,6 @@ defmodule Ethui.Stacks.Stack do
     end)
     |> Enum.into(%{})
   end
+
+  defp filter_anvil_opts(_), do: %{}
 end

--- a/lib/ethui/stacks/stack.ex
+++ b/lib/ethui/stacks/stack.ex
@@ -6,8 +6,11 @@ defmodule Ethui.Stacks.Stack do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @allowed_anvil_opts ~w(fork_url fork_block_number fork_chain_id)
+
   schema "stacks" do
     field(:slug, :string)
+    field(:anvil_opts, :map, default: %{})
     belongs_to(:user, Ethui.Accounts.User)
 
     timestamps(type: :utc_datetime)
@@ -15,9 +18,22 @@ defmodule Ethui.Stacks.Stack do
 
   def create_changeset(attrs) do
     %__MODULE__{}
-    |> cast(attrs, [:slug, :user_id])
+    |> cast(attrs, [:slug, :user_id, :anvil_opts])
     |> validate_required([:slug])
     |> unique_constraint(:slug)
     |> foreign_key_constraint(:user_id)
+    |> update_change(:anvil_opts, &filter_anvil_opts/1)
+  end
+
+  defp filter_anvil_opts(opts) when is_map(opts) do
+    opts
+    |> Enum.filter(fn
+      {k, v} when is_binary(k) ->
+        k in @allowed_anvil_opts and (is_binary(v) or is_number(v))
+
+      _ ->
+        false
+    end)
+    |> Enum.into(%{})
   end
 end

--- a/lib/ethui/stacks/stack.ex
+++ b/lib/ethui/stacks/stack.ex
@@ -6,7 +6,7 @@ defmodule Ethui.Stacks.Stack do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @allowed_anvil_opts ~w(fork_url fork_block_number fork_chain_id)
+  @allowed_anvil_opts ~w(fork_url fork_block_number)
 
   schema "stacks" do
     field(:slug, :string)

--- a/lib/ethui_web/controllers/api/stack_controller.ex
+++ b/lib/ethui_web/controllers/api/stack_controller.ex
@@ -8,20 +8,22 @@ defmodule EthuiWeb.Api.StackController do
   def index(conn, _params) do
     user = conn.assigns[:current_user]
 
-    stacks = if user do
-      Repo.all(from s in Stack, where: s.user_id == ^user.id)
-    else
-      Repo.all(Stack)
-    end
+    stacks =
+      if user do
+        Repo.all(from(s in Stack, where: s.user_id == ^user.id))
+      else
+        Repo.all(Stack)
+      end
 
     running_slugs = Server.list()
 
-    stack_data = Enum.map(stacks, fn stack ->
-      %{
-        slug: stack.slug,
-        status: if(stack.slug in running_slugs, do: "running", else: "stopped")
-      }
-    end)
+    stack_data =
+      Enum.map(stacks, fn stack ->
+        %{
+          slug: stack.slug,
+          status: if(stack.slug in running_slugs, do: "running", else: "stopped")
+        }
+      end)
 
     json(conn, %{
       status: "success",
@@ -33,11 +35,12 @@ defmodule EthuiWeb.Api.StackController do
     user = conn.assigns[:current_user]
 
     # Add user_id to params if user is authenticated
-    stack_params = if user do
-      Map.put(params, "user_id", user.id)
-    else
-      params
-    end
+    stack_params =
+      if user do
+        Map.put(params, "user_id", user.id)
+      else
+        params
+      end
 
     with changeset <- Stack.create_changeset(stack_params),
          {:ok, stack} <- Repo.insert(changeset),

--- a/priv/repo/migrations/20250805141146_add_anvil_opts_to_stacks.exs
+++ b/priv/repo/migrations/20250805141146_add_anvil_opts_to_stacks.exs
@@ -1,0 +1,10 @@
+defmodule Ethui.Repo.Migrations.AddAnvilOptsToStacks do
+  use Ecto.Migration
+
+  def change do
+    alter table(:stacks) do
+      add :anvil_opts, :map, default: fragment("'{}'")
+    end
+
+  end
+end

--- a/test/ethui/services/anvil_test.exs
+++ b/test/ethui/services/anvil_test.exs
@@ -50,7 +50,7 @@ defmodule Ethui.Services.AnvilTest do
         anvil_opts: %{"fork_url" => "https://eth-mainnet.g.alchemy.com/v2/demo"}
       )
 
-    Process.sleep(1000)
+    Process.sleep(10000)
 
     client = Rpc.new_client(:http, rpc_url: Anvil.url(anvil))
 

--- a/test/ethui/services/anvil_test.exs
+++ b/test/ethui/services/anvil_test.exs
@@ -50,7 +50,7 @@ defmodule Ethui.Services.AnvilTest do
         anvil_opts: %{"fork_url" => "https://eth-mainnet.g.alchemy.com/v2/demo"}
       )
 
-    Process.sleep(10000)
+    Process.sleep(10_000)
 
     client = Rpc.new_client(:http, rpc_url: Anvil.url(anvil))
 

--- a/test/ethui/services/anvil_test.exs
+++ b/test/ethui/services/anvil_test.exs
@@ -56,12 +56,12 @@ defmodule Ethui.Services.AnvilTest do
 
     {:ok,
      %Exth.Rpc.Response.Success{
-       result: %{"forkConfig" => %{"forkBlockNumber" => forkBlockNumber}}
+       result: %{"forkConfig" => %{"forkBlockNumber" => fork_block_number}}
      }} =
       Rpc.request("anvil_nodeInfo", [])
       |> Rpc.send(client)
 
-    assert forkBlockNumber
+    assert fork_block_number
 
     Anvil.stop(anvil)
     Process.sleep(100)

--- a/test/ethui/services/anvil_test.exs
+++ b/test/ethui/services/anvil_test.exs
@@ -58,8 +58,6 @@ defmodule Ethui.Services.AnvilTest do
       Rpc.request("anvil_nodeInfo", [])
       |> Rpc.send(client)
 
-    IO.inspect(resp, label: "Anvil response")
-
     assert {:ok, %{"result" => %{"forkConfig" => _}}} = resp
 
     Anvil.stop(anvil)

--- a/test/ethui/services/anvil_test.exs
+++ b/test/ethui/services/anvil_test.exs
@@ -47,18 +47,21 @@ defmodule Ethui.Services.AnvilTest do
         ports: HttpPorts,
         slug: "opt123",
         hash: "hash",
-        anvil_opts: %{"fork_url" => "https://eth-mainnet.g.alchemy.com/v2/demo"}
+        anvil_opts: %{"fork_url" => "wss://mainnet.gateway.tenderly.co"}
       )
 
     Process.sleep(10_000)
 
     client = Rpc.new_client(:http, rpc_url: Anvil.url(anvil))
 
-    resp =
+    {:ok,
+     %Exth.Rpc.Response.Success{
+       result: %{"forkConfig" => %{"forkBlockNumber" => forkBlockNumber}}
+     }} =
       Rpc.request("anvil_nodeInfo", [])
       |> Rpc.send(client)
 
-    assert {:ok, %{"result" => %{"forkConfig" => _}}} = resp
+    assert forkBlockNumber
 
     Anvil.stop(anvil)
     Process.sleep(100)

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -47,10 +47,10 @@ defmodule EthuiWeb.ConnCase do
   def authenticated_api_conn do
     # Create a test user
     {:ok, user} = Ethui.Accounts.send_verification_code("test@example.com")
-    
+
     # Generate a JWT token for the user
     {:ok, token} = Ethui.Accounts.generate_token(user)
-    
+
     # Build API connection with Authorization header
     Phoenix.ConnTest.build_conn(:post, "http://api.lvh.me", nil)
     |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")


### PR DESCRIPTION
### Why 
We want a way to pass optional argument to anvil , for example, to fork a specific network at a specific time.

### How 
Add an optional param on the stack creation endpoint to pass a json map with the optional parameters. 
This params are allow listed on the `anvil.ex` file with the module attribute `@allowed_anvil_opts`. 
Right now we support the basic fork url, fork  block number and chain id.