### PR TITLE
Move to unique chain ids and clean up anvil state after removal

### DIFF
--- a/lib/ethui/services/anvil.ex
+++ b/lib/ethui/services/anvil.ex
@@ -45,7 +45,6 @@ defmodule Ethui.Services.Anvil do
     {:via, Registry, {Ethui.Stacks.Registry, {slug, :anvil}}}
   end
 
-
   #
   # Client
 
@@ -78,8 +77,6 @@ defmodule Ethui.Services.Anvil do
     GenServer.cast(id, :stop)
   end
 
-
-
   #
   # Server
   #
@@ -94,7 +91,6 @@ defmodule Ethui.Services.Anvil do
          {:ok, port} <-
            Ethui.Stacks.HttpPorts.claim() do
       send(self(), :boot)
-
 
       {:ok,
        %{
@@ -157,7 +153,6 @@ defmodule Ethui.Services.Anvil do
         {:stop, :normal, state}
     end
   end
-  
 
   @impl GenServer
   def handle_call(:url, _from, %{port: port} = state) do
@@ -175,10 +170,6 @@ defmodule Ethui.Services.Anvil do
     GenServer.stop(proc)
     {:stop, :normal, state}
   end
-
-
-
-
 
   @impl GenServer
   def handle_cast({:log, line}, %{logs: logs, log_subscribers: subs} = state) do
@@ -209,14 +200,12 @@ defmodule Ethui.Services.Anvil do
     case File.rm_rf(state.dir) do
       {:ok, _files} ->
         :ok
-      
+
       {:error, reason, _} ->
         Logger.error("Failed to cleanup resource for slug #{state.slug}: #{inspect(reason)}")
         {:error, reason}
     end
   end
-
-
 
   defp trim(q) do
     if :queue.len(q) > @log_max_size do

--- a/lib/ethui/stacks/multi_stack_supervisor.ex
+++ b/lib/ethui/stacks/multi_stack_supervisor.ex
@@ -23,7 +23,6 @@ defmodule Ethui.Stacks.MultiStackSupervisor do
 
   @spec start_stack(opts) :: {:ok, pid} | {:error, any}
   def start_stack(opts) do
-
     opts = [
       slug: opts[:slug],
       anvil: [id: opts[:id], slug: opts[:slug], hash: opts[:hash], anvil_opts: opts[:anvil_opts]],

--- a/lib/ethui/stacks/server.ex
+++ b/lib/ethui/stacks/server.ex
@@ -118,7 +118,13 @@ defmodule Ethui.Stacks.Server do
 
   @spec start_stack(map, t) :: {:ok, pid, t} | {:error, any}
   defp start_stack(
-         %{id: id, slug: slug, anvil_opts: anvil_opts, graph_opts: graph_opts, inserted_at: inserted_at},
+         %{
+           id: id,
+           slug: slug,
+           anvil_opts: anvil_opts,
+           graph_opts: graph_opts,
+           inserted_at: inserted_at
+         },
          %{instances: instances} = state
        ) do
     hash =
@@ -127,7 +133,7 @@ defmodule Ethui.Stacks.Server do
       |> binary_part(0, 8)
       |> String.downcase()
 
-    full_opts = [id: id,  slug: slug, hash: hash, anvil_opts: anvil_opts, graph_opts: graph_opts]
+    full_opts = [id: id, slug: slug, hash: hash, anvil_opts: anvil_opts, graph_opts: graph_opts]
     Logger.info("Starting stack #{slug}")
 
     case MultiStackSupervisor.start_stack(full_opts) do

--- a/lib/ethui_web/controllers/api/stack_controller.ex
+++ b/lib/ethui_web/controllers/api/stack_controller.ex
@@ -44,7 +44,7 @@ defmodule EthuiWeb.Api.StackController do
       end
 
     with changeset <- Stack.create_changeset(stack_params),
-         {:ok, stack} <- Repo.insert(changeset), 
+         {:ok, stack} <- Repo.insert(changeset),
          _ <- Server.start(stack) do
       conn
       |> put_status(201)

--- a/test/ethui/services/anvil_test.exs
+++ b/test/ethui/services/anvil_test.exs
@@ -20,7 +20,7 @@ defmodule Ethui.Services.AnvilTest do
   end
 
   test "creates an anvil process" do
-    {:ok, anvil} = Anvil.start_link(ports: HttpPorts, slug: "slug123", hash: "hash")
+    {:ok, anvil} = Anvil.start_link(ports: HttpPorts, slug: "slug123", hash: "hash", id: 1)
     Process.sleep(1000)
 
     client = Rpc.new_client(:http, rpc_url: Anvil.url(anvil))
@@ -47,7 +47,8 @@ defmodule Ethui.Services.AnvilTest do
         ports: HttpPorts,
         slug: "opt123",
         hash: "hash",
-        anvil_opts: %{"fork_url" => "wss://mainnet.gateway.tenderly.co"}
+        anvil_opts: %{"fork_url" => "wss://mainnet.gateway.tenderly.co"},
+        id: 1
       )
 
     Process.sleep(10_000)
@@ -76,7 +77,7 @@ defmodule Ethui.Services.AnvilTest do
   test "creates multiple anvil processes" do
     anvils =
       for i <- 1..10 do
-        {:ok, pid} = Anvil.start_link(ports: HttpPorts, slug: :"anvil_#{i}", hash: "hash")
+        {:ok, pid} = Anvil.start_link(ports: HttpPorts, slug: :"anvil_#{i}", hash: "hash", id: 1)
         Process.monitor(pid)
         pid
       end

--- a/test/ethui/stacks/server_test.exs
+++ b/test/ethui/stacks/server_test.exs
@@ -18,8 +18,8 @@ defmodule Ethui.Stacks.ServerTest do
   end
 
   test "can orchestrate multiple anvils" do
-    s1 = %Stack{slug: "slug1"}
-    s2 = %Stack{slug: "slug2"}
+    s1 = %Stack{id: 1, slug: "slug1"}
+    s2 = %Stack{id: 2, slug: "slug2"}
 
     Server.start(s1)
     Server.start(s2)
@@ -30,7 +30,7 @@ defmodule Ethui.Stacks.ServerTest do
   end
 
   test "can start and stop a stack" do
-    stack = %Stack{slug: "test_stack"}
+    stack = %Stack{id: 1, slug: "test_stack"}
 
     assert Server.list() |> length == 0
 

--- a/test/ethui_web/controllers/proxy_controller_test.exs
+++ b/test/ethui_web/controllers/proxy_controller_test.exs
@@ -21,7 +21,7 @@ defmodule EthuiWeb.ProxyControllerTest do
     test "proxies to anvil" do
       slug = "slug10"
 
-      s = %Stack{slug: slug}
+      s = %Stack{slug: slug, id: 1}
       Server.start(s)
       Process.sleep(100)
 


### PR DESCRIPTION
#### Why
Currently all the stacks had the same chain id which was causing problems with other components in ethui .
When we removed a stack it was not deleting its anvil state , which means when a stack with the same name was created it was using the state from the previous stack . 

#### How 
* Used the already existing stacks id to calculate the chain id , so each stack has a unique chain id .
* On removal it calls the stop function on the anvil service that removes the directory used by that anvil and stops the gen server gracefully .