### PR TITLE
fix: preserve historical anvil state across suspends

### DIFF
--- a/server/lib/ethui/services/anvil.ex
+++ b/server/lib/ethui/services/anvil.ex
@@ -326,6 +326,10 @@ defmodule Ethui.Services.Anvil do
         to_string(port),
         "--state",
         "#{dir}/state.json",
+        # Without this, every suspend/resume cycle silently drops pre-restart state:
+        # blocks and logs survive, but eth_call at any older block fails with
+        # BlockOutOfRangeError, which breaks indexers replaying chain history.
+        "--preserve-historical-states",
         "--host",
         "0.0.0.0",
         "--chain-id",


### PR DESCRIPTION
Adds `--preserve-historical-states` to the anvil args.

The idle suspend kills anvil and resumes it from `--state state.json`, which restores blocks and logs but not historical state — after any resume, `eth_call` at a pre-restart block fails with `BlockOutOfRangeError`. Any indexer replaying chain history breaks (the bullish staging Ponder indexer hit this today: it backfills events from block 0 and pins reads to each event's block).

Verified locally with anvil v1.7: mine + transact, kill, resume with the flag → `eth_getBalance` at pre-restart blocks returns correct historical values; without the flag the same query fails.

Note for existing stacks: state dropped by past suspends is unrecoverable — the flag only protects history written after it's in effect. Chains that need queryable history from genesis have to be reset once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)